### PR TITLE
Add 'hotload' function instead of using os.execute

### DIFF
--- a/example/sketchybarrc
+++ b/example/sketchybarrc
@@ -14,7 +14,7 @@ sbar = require("sketchybar")
 -- Load the init.lua file
 require("init")
 
-os.execute("sketchybar --hotload on")
+sbar.hotload(true)
 
 -- Run the event loop of the sketchybar module (without this there will be no
 -- bi-directional communication between the lua module and sketchybar)


### PR DESCRIPTION
Add 'hotload' function, taking a boolean for the hotload state, to use instead of using os.execute.

Also I just wanted something simple so I could figure out exactly how the Lua<->C interop works before trying something more difficult.